### PR TITLE
Add multi cert access to dev.xal.no users

### DIFF
--- a/enable_ssh.sh
+++ b/enable_ssh.sh
@@ -1,3 +1,17 @@
 #! /bin/bash
-cp /xal/internal/pub_keys/$1/* /home/$1/.ssh/authorized_keys
+base_path=/xal/internal
+
+num_files=$(ls -1 ${base_path}/pub_keys/$1/ | wc -l)
+if (( num_files > 1)); then
+    rm -f ${base_path}/pub_keys/$1/generated_authorized_keys
+    keys=$(find ${base_path}/pub_keys/$1 | egrep '\.pub\>')
+    for key in $keys
+    do
+        cat $key >> ${base_path}/pub_keys/$1/generated_authorized_keys
+    done
+    mv /xal/internal/pub_keys/$1/generated_authorized_keys /home/$1/.ssh/authorized_keys
+else
+    cp /xal/internal/pub_keys/$1/* /home/$1/.ssh/authorized_keys
+fi
+
 chown $1 /home/$1/.ssh/*


### PR DESCRIPTION
This PR concatenates all the `.pub` files in a user's pubkey-directory into an `authorized_keys` entry for `dev.xal.no`.